### PR TITLE
Fix instance blocking on startup script

### DIFF
--- a/files/puppet-enterprise.sh
+++ b/files/puppet-enterprise.sh
@@ -191,8 +191,12 @@ function provision_puppet() {
     install_puppetagent
   fi
 
-  #/opt/puppet/bin/puppet agent --onetime --no-daemonize --color=false --verbose --splay --splaylimit 30 --waitforcert
-  /opt/puppet/bin/puppet agent --onetime --no-daemonize --color=false --verbose --waitforcert
+  if [ $PUPPET_PE_ROLE = 'master' ]; then
+    /opt/puppet/bin/puppet agent --onetime --no-daemonize --color=false --verbose
+  else
+    /opt/puppet/bin/puppet agent --onetime --no-daemonize --color=false --verbose --splay --splaylimit 30 --waitforcert 120
+  fi
+
   echo $? > $RESULTS_FILE
   echo "Puppet installation finished!"
   exit 0

--- a/lib/puppet/type/gce_instance.rb
+++ b/lib/puppet/type/gce_instance.rb
@@ -124,7 +124,7 @@ Puppet::Type.newtype(:gce_instance) do
   end
   newparam(:startup_script_timeout) do
     desc 'timeout for bootstrap script. If this time is passed before the bootstrap script has finished, the resource will fail'
-    defaultto '300'
+    defaultto '420'
     munge do |value|
       Integer(value)
     end


### PR DESCRIPTION
This commit fixes the failure in the puppet-enterprise script that
caused the block_for_startup_script parameter to function improperly.
The script will now only wait-for-cert on agents and the default
timeout to block has been set at 7 minutes.
