### PR TITLE
Added commands to create disk from snapshot

### DIFF
--- a/lib/puppet/provider/gce_disk/gcutil.rb
+++ b/lib/puppet/provider/gce_disk/gcutil.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:gce_disk).provide(
   end
 
   def parameter_list
-    [ 'zone', 'size_gb', 'description', 'wait_until_complete', 'source_image' ]
+    [ 'zone', 'size_gb', 'description', 'wait_until_complete', 'source_image', 'source_snapshot']
   end
 
   def destroy_parameter_list

--- a/lib/puppet/type/gce_disk.rb
+++ b/lib/puppet/type/gce_disk.rb
@@ -29,6 +29,10 @@ Puppet::Type.newtype(:gce_disk) do
     desc 'boot image to use when creating disk'
   end
 
+  newparam(:source_snapshot) do
+    desc 'boot snapshot to use when creating disk'
+  end
+
   newparam(:wait_until_complete) do
     desc 'wait until disk is complete'
   end


### PR DESCRIPTION
I needed to create a disk from a snapshot as opposed to just an image for a work project.  It was a simple change and I saw it would be in a future update.