### PR TITLE
Fix metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,12 @@
 {
+  "name": "puppetlabs-gce_compute",
+  "version": "0.5.0",
+  "author": "Puppet Labs",
+  "summary": "Native types for managing Google Cloud Platform infrastructure as Puppet DSL.",
+  "license": "Apache 2.0",
+  "source": "https://github.com/puppetlabs/puppetlabs-gce_compute",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-gce_compute",
+  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
@@ -36,7 +44,7 @@
         "12.04",
         "14.04"
       ]
-    },
+    }
   ],
   "requirements": [
     {
@@ -48,13 +56,8 @@
       "version_requirement": "3.x"
     }
   ],
-  "name": "puppetlabs-gce_compute",
-  "version": "0.5.0",
-  "source": "git://github.com/puppetlabs/puppetlabs-gce_compute.git",
-  "author": "Puppet Labs",
-  "license": "Apache 2.0",
-  "summary": "Native types for managing Google Cloud Platform infrastructure as Puppet DSL.",
   "description": "GCE Module for Puppet using gcloud SDK",
-  "project_page": "http://github.com/puppetlabs/puppetlabs-gce_compute",
-  "dependencies": []
+  "dependencies": [
+  
+  ]
 }


### PR DESCRIPTION
Remove trailing comma, and use the metadata file generate by puppet
module build.
