### PR TITLE
Gce instance secondary disk

### DIFF
--- a/lib/puppet/provider/gce_instance/gcloud.rb
+++ b/lib/puppet/provider/gce_instance/gcloud.rb
@@ -37,6 +37,7 @@ Puppet::Type.type(:gce_instance).provide(:gcloud, :parent => Puppet::Provider::G
     args = build_gcloud_args('create') + build_gcloud_flags(gcloud_optional_create_args)
     append_can_ip_forward_args(args, resource)
     append_boot_disk_args(args, resource)
+    append_secondary_disk_args(args, resource)
     append_metadata_args(args, resource)
     append_startup_script_args(args, resource)
     gcloud(*args)
@@ -52,6 +53,13 @@ Puppet::Type.type(:gce_instance).provide(:gcloud, :parent => Puppet::Provider::G
       args << '--disk'
       args << "name=#{resource[:boot_disk]},boot=yes"
     end
+  end
+
+  def append_secondary_disk_args(args, resource)
+      if resource[:secondary_disk]
+          args << '--disk'
+          args << "name=#{resource[:secondary_disk]}"
+      end
   end
 
   def append_metadata_args(args, resource)

--- a/lib/puppet/provider/gce_instance/gcloud.rb
+++ b/lib/puppet/provider/gce_instance/gcloud.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:gce_instance).provide(:gcloud, :parent => Puppet::Provider::G
   def append_secondary_disk_args(args, resource)
       if resource[:secondary_disk]
           args << '--disk'
-          args << "name=#{resource[:secondary_disk]}"
+          args << "name=#{resource[:secondary_disk]}#{resource[:secondary_disk_name] ? ',device-name=' + resource[:secondary_disk_name] : ''}"
       end
   end
 

--- a/lib/puppet/type/gce_instance.rb
+++ b/lib/puppet/type/gce_instance.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:gce_instance) do
   end
 
   newparam(:secondary_disk) do
-    desc 'Specifies an optional list of secondary disks to be attached to this instance.'
+    desc 'Specifies an optional secondary disk to be attached to this instance.'
   end
 
   newparam(:image) do

--- a/lib/puppet/type/gce_instance.rb
+++ b/lib/puppet/type/gce_instance.rb
@@ -36,6 +36,10 @@ Puppet::Type.newtype(:gce_instance) do
     desc 'Specifies an optional secondary disk to be attached to this instance.'
   end
 
+  newparam(:secondary_disk_name) do
+    desc 'Specifies the device name of the secondary disk. Only applies if secondary_disk is specified.'
+  end
+
   newparam(:image) do
    desc 'Specifies the boot image for the instance.'
   end

--- a/lib/puppet/type/gce_instance.rb
+++ b/lib/puppet/type/gce_instance.rb
@@ -32,6 +32,10 @@ Puppet::Type.newtype(:gce_instance) do
     desc 'Specifies a persistent disk as the boot disk for this instance.'
   end
 
+  newparam(:secondary_disk) do
+    desc 'Specifies an optional list of secondary disks to be attached to this instance.'
+  end
+
   newparam(:image) do
    desc 'Specifies the boot image for the instance.'
   end


### PR DESCRIPTION
This adds the ability to add a secondary disk when creating a gce instance
